### PR TITLE
Make frame results horizontally scrollable

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -145,8 +145,9 @@ def run_analysis_per_frame(
     on_frame_start_index: Callable[[int, int], None],
     on_frame_intermediate: Callable[[int, str], None] | None,
     on_frame_result: Callable[[int, str], None],
-    on_complete: Callable[[int], None],
+    on_complete: Callable[[int, int, bool], None],
     on_error: Callable[[str], None],
+    should_cancel: Callable[[], bool] | None = None,
 ) -> None:
     """
     フレームを抽出し、on_frames_ready で渡したあと、
@@ -162,7 +163,12 @@ def run_analysis_per_frame(
         model = config.get("ollama_model", "llava")
         japanese_model = config.get("ollama_japanese_model")
         n = len(frames)
+        error_count = 0
+        cancelled = False
         for i, frame_jpeg in enumerate(frames):
+            if should_cancel is not None and should_cancel():
+                cancelled = True
+                break
             current = i + 1
             on_frame_start_index(current, n)
             on_progress(f"フレーム {current}/{n} を解析中…")
@@ -175,11 +181,15 @@ def run_analysis_per_frame(
                     base_url=base_url,
                     model=model,
                 )
+                if should_cancel is not None and should_cancel():
+                    cancelled = True
+                    break
                 if on_frame_intermediate is not None and japanese_model:
                     on_frame_intermediate(i, english or "")
 
                 # 第2段階: 日本語翻訳（指定があれば）。結果は最終版として表示。
                 if japanese_model:
+                    on_progress(f"フレーム {current}/{n} を翻訳中…")
                     result = _translate_report_to_japanese(
                         english or "",
                         base_url=base_url,
@@ -189,8 +199,9 @@ def run_analysis_per_frame(
                     result = english
                 on_frame_result(i, result or "")
             except Exception as e:
+                error_count += 1
                 on_frame_result(i, f"エラー: {e}")
-        on_complete(n)
+        on_complete(n, error_count, cancelled)
     except Exception as e:
         on_error(str(e))
 
@@ -218,6 +229,8 @@ class VideoAnalyzerApp(tk.Tk):
         self._progress_status_var = tk.StringVar(value="")
         self._progress_bar: ttk.Progressbar | None = None
         self._progress_frame: ttk.Frame | None = None
+        self._cancel_btn: ttk.Button | None = None
+        self._cancel_requested = False
         self._interval_var = tk.StringVar(value="10")
         self._summary_btn: ttk.Button | None = None
         self._summary_text: tk.Text | None = None
@@ -299,11 +312,42 @@ class VideoAnalyzerApp(tk.Tk):
         )
         interval_combo.pack(side=tk.LEFT)
         ttk.Label(interval_frame, text="秒").pack(side=tk.LEFT, padx=(2, 0))
+        ttk.Label(
+            interval_frame,
+            text="短いほど詳細に解析できますが、処理時間が長くなります。",
+            style="Muted.TLabel",
+        ).pack(side=tk.LEFT, padx=(12, 0))
 
         # 動画ファイル情報
         info_frame = ttk.LabelFrame(main, text="動画ファイル情報", padding=(16, 12))
         info_frame.pack(fill=tk.X, pady=(0, 12))
         ttk.Label(info_frame, textvariable=self._info_var, wraplength=600).pack(anchor=tk.W)
+
+        # 解析状況: 長時間の Ollama 応答待ちをユーザーが把握できるよう常時表示する。
+        self._progress_frame = ttk.LabelFrame(main, text="解析状況", padding=(16, 10))
+        self._progress_frame.pack(fill=tk.X, pady=(0, 12))
+        progress_row = ttk.Frame(self._progress_frame)
+        progress_row.pack(fill=tk.X)
+        ttk.Label(
+            progress_row,
+            textvariable=self._progress_status_var,
+            style="Section.TLabel",
+        ).pack(side=tk.LEFT, fill=tk.X, expand=True)
+        self._cancel_btn = ttk.Button(
+            progress_row,
+            text="キャンセル",
+            command=self._on_cancel,
+            state=tk.DISABLED,
+        )
+        self._cancel_btn.pack(side=tk.RIGHT, padx=(12, 0))
+        self._progress_bar = ttk.Progressbar(
+            self._progress_frame,
+            orient=tk.HORIZONTAL,
+            mode="determinate",
+            maximum=100,
+        )
+        self._progress_bar.pack(fill=tk.X, pady=(8, 0))
+        self._progress_status_var.set("待機中")
 
         # メインコンテンツ：上＝フレーム解析結果、下＝総評（縦分割で総評の表示エリアを確保）
         SUMMARY_PANE_MIN_HEIGHT = 320  # 総評エリアの最小高さ（ピクセル）
@@ -342,6 +386,7 @@ class VideoAnalyzerApp(tk.Tk):
 
         self._results_inner = ttk.Frame(self._results_canvas)
         self._results_win_id = self._results_canvas.create_window((0, 0), window=self._results_inner, anchor="nw")
+        self._show_empty_state()
 
         def _on_cards_inner_configure(_e):
             if self._results_canvas:
@@ -429,21 +474,39 @@ class VideoAnalyzerApp(tk.Tk):
 
     def _show_progress(self, msg: str, current: int, total: int):
         """状況エリアのメッセージとプログレスバーを更新"""
+        self.status_var.set(msg)
         self._progress_status_var.set(msg)
         if self._progress_bar is not None:
-            self._progress_bar["value"] = (current / total * 100) if total > 0 else 0
+            self._progress_bar.stop()
+            if total > 0:
+                self._progress_bar.configure(mode="determinate")
+                self._progress_bar["value"] = min(100.0, max(0.0, current / total * 100))
+            else:
+                self._progress_bar.configure(mode="indeterminate")
+                self._progress_bar.start(12)
 
     def _update_progress(self, msg: str, current: int, total: int):
         """状況メッセージとプログレスバーを更新"""
+        self.status_var.set(msg)
         self._progress_status_var.set(msg)
         if self._progress_bar is not None and total > 0:
+            self._progress_bar.stop()
+            self._progress_bar.configure(mode="determinate")
             self._progress_bar["value"] = min(100.0, (current / total) * 100)
 
     def _hide_progress(self, message: str = "完了"):
         """解析終了後の状況表示（既定: 完了、エラー時は別メッセージ）"""
         self._progress_status_var.set(message)
+        self.status_var.set(message)
+        if self._cancel_btn is not None:
+            self._cancel_btn.configure(state=tk.DISABLED)
         if self._progress_bar is not None and message == "完了":
+            self._progress_bar.stop()
+            self._progress_bar.configure(mode="determinate")
             self._progress_bar["value"] = 100
+        elif self._progress_bar is not None:
+            self._progress_bar.stop()
+            self._progress_bar.configure(mode="determinate")
 
     def _on_shift_scroll(self, event):
         """Shift+マウスホイールで横スクロール（操作したキャンバスをスクロール）"""
@@ -456,6 +519,13 @@ class VideoAnalyzerApp(tk.Tk):
         w = event.widget
         if isinstance(w, tk.Canvas):
             w.yview_scroll(int(-1 * (event.delta / 120)), "units")
+
+    def _on_cancel(self):
+        self._cancel_requested = True
+        self.status_var.set("キャンセル要求中です。現在のOllama処理が戻るまで待機します…")
+        self._progress_status_var.set("キャンセル要求中です。現在のOllama処理が戻るまで待機します…")
+        if self._cancel_btn is not None:
+            self._cancel_btn.configure(state=tk.DISABLED)
 
     def _on_browse(self):
         path = filedialog.askopenfilename(
@@ -504,6 +574,15 @@ class VideoAnalyzerApp(tk.Tk):
             if canvas:
                 canvas.xview_moveto(0)
                 canvas.yview_moveto(0)
+
+    def _show_empty_state(self):
+        if self._results_inner is None:
+            return
+        ttk.Label(
+            self._results_inner,
+            text="動画を選択して実行すると、抽出したフレームと解析結果がここに表示されます。",
+            style="Muted.TLabel",
+        ).pack(anchor=tk.W, padx=12, pady=16)
 
     def _build_cards(self, frames_jpeg: list[bytes]):
         """画像+解析結果を同一カードにまとめ、カードを横並びで作成する"""
@@ -620,14 +699,17 @@ class VideoAnalyzerApp(tk.Tk):
             return
         config = self._get_config()
 
+        self._cancel_requested = False
         self.analyze_btn.configure(state=tk.DISABLED)
+        if self._cancel_btn is not None:
+            self._cancel_btn.configure(state=tk.NORMAL)
         self._clear_cards()
         self.status_var.set("フレームを抽出しています…")
         self._show_progress("フレームを抽出しています…", 0, 0)
         self.update_idletasks()
 
         def on_progress(msg: str):
-            self.after(0, lambda: self.status_var.set(msg))
+            self.after(0, lambda: self._show_progress(msg, 0, 0))
 
         def on_frame_start_index(current: int, total: int):
             def _update():
@@ -758,10 +840,9 @@ class VideoAnalyzerApp(tk.Tk):
 
             self.after(0, _update)
 
-        def on_complete(total: int):
+        def on_complete(total: int, error_count: int, cancelled: bool):
             def _update():
-                self._on_analysis_complete(total)
-                self._hide_progress()
+                self._on_analysis_complete(total, error_count, cancelled)
 
             self.after(0, _update)
 
@@ -788,19 +869,28 @@ class VideoAnalyzerApp(tk.Tk):
                 on_frame_result,
                 on_complete,
                 on_error,
+                lambda: self._cancel_requested,
             )
 
         thread = threading.Thread(target=work, daemon=True)
         thread.start()
 
-    def _on_analysis_complete(self, total: int):
-        self.status_var.set(f"完了（{total} フレーム解析）")
+    def _on_analysis_complete(self, total: int, error_count: int = 0, cancelled: bool = False):
+        if cancelled:
+            message = f"キャンセルしました（{total} フレーム中 {error_count} 件エラー）"
+        elif error_count:
+            message = f"一部失敗（{total} フレーム中 {error_count} 件エラー）"
+        else:
+            message = f"完了（{total} フレーム解析）"
+        self._hide_progress(message)
         self.analyze_btn.configure(state=tk.NORMAL)
         if self._summary_btn:
-            self._summary_btn.configure(state=tk.NORMAL)
+            self._summary_btn.configure(state=tk.NORMAL if not cancelled else tk.DISABLED)
+        if error_count and not cancelled:
+            messagebox.showwarning("解析は一部失敗しました", "一部フレームの解析に失敗しました。各フレームのエラー内容を確認してください。")
 
     def _on_analysis_error(self, msg: str):
-        self.status_var.set("解析に失敗しました")
+        self._hide_progress("解析に失敗しました")
         self.analyze_btn.configure(state=tk.NORMAL)
         messagebox.showerror("解析エラー", msg)
 

--- a/gui.py
+++ b/gui.py
@@ -24,7 +24,10 @@ from app.video_analyzer import (
     analyze_video,
     extract_frames_every_n_seconds,
     get_summary_from_frame_results,
+    _ollama_client,
 )
+from app.position_reference import get_position_reference_for_prompt
+from app.prompt_text import render_frame_analysis_prompt
 from app.logger import log_event
 
 load_dotenv()
@@ -40,6 +43,115 @@ SUMMARY_PERSONA_CHOICES: list[tuple[str, str]] = [
     ("otaku_girl_lewd", "興味津々オタク女子"),
 ]
 _SUMMARY_LABEL_TO_KEY = {label: key for key, label in SUMMARY_PERSONA_CHOICES}
+
+FRAME_PROMPT_TESTS: list[dict[str, str]] = [
+    {
+        "key": "current",
+        "label": "既存: 詳細レポート",
+        "focus": "既存の人物・背景・行為詳細",
+        "prompt": "",
+    },
+    {
+        "key": "brief",
+        "label": "新規1: 短文要約",
+        "focus": "一目で分かる短い要約",
+        "prompt": (
+            "画像を見て、日本語で3行以内に要約してください。\n"
+            "1行目: 主な被写体\n"
+            "2行目: 背景や場所\n"
+            "3行目: 目立つ行動や状態\n"
+            "推測しすぎず、見えている内容だけを書いてください。"
+        ),
+    },
+    {
+        "key": "tags",
+        "label": "新規2: タグ抽出",
+        "focus": "検索・分類しやすいタグ",
+        "prompt": (
+            "画像を分類するためのタグを日本語で抽出してください。\n"
+            "出力形式:\n"
+            "人物タグ: ...\n"
+            "背景タグ: ...\n"
+            "服装/外見タグ: ...\n"
+            "行動タグ: ...\n"
+            "不確実なタグ: ...\n"
+            "各項目はカンマ区切りで簡潔にしてください。"
+        ),
+    },
+    {
+        "key": "safety",
+        "label": "新規3: 判定重視",
+        "focus": "有無判定と根拠",
+        "prompt": (
+            "画像内の重要な状態を判定し、根拠を短く説明してください。\n"
+            "出力形式:\n"
+            "人物の有無: あり/なし/不明\n"
+            "露出の有無: あり/なし/不明\n"
+            "性的行為の有無: あり/なし/不明\n"
+            "根拠: 画面内で確認できる視覚情報を1〜3文で説明\n"
+            "不明な場合は不明と明記してください。"
+        ),
+    },
+]
+
+
+def _render_frame_prompt_test_prompt(test_key: str) -> str:
+    """プロンプトテスト用の本文を返す。既存プロンプトは通常解析と同じ本文を使う。"""
+    if test_key == "current":
+        return render_frame_analysis_prompt(get_position_reference_for_prompt())
+    for item in FRAME_PROMPT_TESTS:
+        if item["key"] == test_key:
+            return item["prompt"]
+    raise KeyError(f"unknown prompt test key: {test_key}")
+
+
+def _frame_prompt_tests_for_run() -> list[dict[str, str]]:
+    """実行時に既存プロンプト本文も展開した比較用プロンプト一覧を返す。"""
+    tests: list[dict[str, str]] = []
+    for item in FRAME_PROMPT_TESTS:
+        tests.append(
+            {
+                "key": item["key"],
+                "label": item["label"],
+                "focus": item["focus"],
+                "prompt": _render_frame_prompt_test_prompt(item["key"]),
+            }
+        )
+    return tests
+
+
+def _truncate_for_table(text: str, limit: int = 500) -> str:
+    s = (text or "").strip()
+    if len(s) <= limit:
+        return s
+    return s[:limit] + f"\n... ({len(s)}文字)"
+
+
+def _run_frame_prompt_once(
+    frame_jpeg: bytes,
+    prompt: str,
+    *,
+    base_url: str,
+    model: str,
+) -> str:
+    """1枚のフレームに任意プロンプトを1回投げる。プロンプト比較専用。"""
+    client = _ollama_client(base_url)
+    b64 = base64.standard_b64encode(frame_jpeg).decode("ascii")
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
+                ],
+            }
+        ],
+        max_tokens=2048,
+        temperature=0.2,
+    )
+    return (response.choices[0].message.content or "").strip()
 
 EMPTY_FRAME_RESULT_PLACEHOLDER = (
     "（モデルから本文が返りませんでした。ラベルは「完了（本文なし）」と表示されます。）\n\n"
@@ -239,6 +351,11 @@ class VideoAnalyzerApp(tk.Tk):
         self._summary_text: tk.Text | None = None
         self._summary_placeholder_var = tk.StringVar(value="総評ウィンドウで生成結果を表示します。")
         self._summary_persona_var = tk.StringVar(value=SUMMARY_PERSONA_CHOICES[0][1])
+        self._prompt_test_window: tk.Toplevel | None = None
+        self._prompt_test_btn: ttk.Button | None = None
+        self._prompt_test_run_btn: ttk.Button | None = None
+        self._prompt_test_tree: ttk.Treeview | None = None
+        self._prompt_test_frame_var = tk.StringVar(value="1")
         # カード作成前に届いた解析結果を保持（レース対策）
         self._pending_frame_results: dict[int, str] = {}
         self._design = _DESIGN
@@ -441,6 +558,13 @@ class VideoAnalyzerApp(tk.Tk):
             style="Accent.TButton",
         )
         self._summary_window_btn.pack(side=tk.RIGHT)
+        self._prompt_test_btn = ttk.Button(
+            result_toolbar,
+            text="プロンプトテスト",
+            command=self._open_prompt_test_window,
+            state=tk.DISABLED,
+        )
+        self._prompt_test_btn.pack(side=tk.RIGHT, padx=(0, 8))
         ttk.Label(
             result_frame,
             text="横に並んだフレームは下の横スクロールバー、または Shift + マウスホイールで移動できます。",
@@ -651,6 +775,169 @@ class VideoAnalyzerApp(tk.Tk):
     def _open_summary_window(self):
         self._ensure_summary_window()
 
+    def _ensure_prompt_test_window(self) -> tk.Toplevel:
+        if self._prompt_test_window is not None and self._prompt_test_window.winfo_exists():
+            self._prompt_test_window.deiconify()
+            self._prompt_test_window.lift()
+            return self._prompt_test_window
+
+        d = self._design
+        win = tk.Toplevel(self)
+        win.title("プロンプトテスト")
+        win.geometry("980x560")
+        win.minsize(760, 420)
+        win.configure(bg=d["bg"])
+        win.protocol("WM_DELETE_WINDOW", win.withdraw)
+        self._prompt_test_window = win
+
+        main = ttk.Frame(win, padding=(16, 12))
+        main.pack(fill=tk.BOTH, expand=True)
+
+        controls = ttk.Frame(main)
+        controls.pack(fill=tk.X, pady=(0, 8))
+        ttk.Label(controls, text="対象フレーム:").pack(side=tk.LEFT, padx=(0, 6))
+        self._prompt_test_frame_combo = ttk.Combobox(
+            controls,
+            textvariable=self._prompt_test_frame_var,
+            state="readonly",
+            width=12,
+        )
+        self._prompt_test_frame_combo.pack(side=tk.LEFT, padx=(0, 12))
+        self._prompt_test_run_btn = ttk.Button(
+            controls,
+            text="4プロンプトを比較",
+            command=self._run_prompt_test,
+            state=tk.NORMAL if self._frame_cards else tk.DISABLED,
+            style="Accent.TButton",
+        )
+        self._prompt_test_run_btn.pack(side=tk.LEFT)
+        ttk.Label(
+            controls,
+            text="既存プロンプト1つと新規3つを同じフレームで比較します。",
+            style="Muted.TLabel",
+        ).pack(side=tk.LEFT, padx=(12, 0))
+
+        columns = ("prompt", "focus", "result")
+        tree_frame = ttk.Frame(main)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
+        tree_scroll_y = ttk.Scrollbar(tree_frame, orient=tk.VERTICAL)
+        tree_scroll_y.pack(side=tk.RIGHT, fill=tk.Y)
+        tree_scroll_x = ttk.Scrollbar(tree_frame, orient=tk.HORIZONTAL)
+        tree_scroll_x.pack(side=tk.BOTTOM, fill=tk.X)
+        self._prompt_test_tree = ttk.Treeview(
+            tree_frame,
+            columns=columns,
+            show="headings",
+            yscrollcommand=tree_scroll_y.set,
+            xscrollcommand=tree_scroll_x.set,
+            height=10,
+        )
+        tree_scroll_y.configure(command=self._prompt_test_tree.yview)
+        tree_scroll_x.configure(command=self._prompt_test_tree.xview)
+        self._prompt_test_tree.heading("prompt", text="プロンプト")
+        self._prompt_test_tree.heading("focus", text="狙い")
+        self._prompt_test_tree.heading("result", text="結果")
+        self._prompt_test_tree.column("prompt", width=180, minwidth=140, stretch=False)
+        self._prompt_test_tree.column("focus", width=220, minwidth=160, stretch=False)
+        self._prompt_test_tree.column("result", width=620, minwidth=360, stretch=True)
+        self._prompt_test_tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        self._refresh_prompt_test_frames()
+        return win
+
+    def _open_prompt_test_window(self):
+        self._ensure_prompt_test_window()
+
+    def _refresh_prompt_test_frames(self):
+        values = [f"フレーム{i + 1}" for i in range(len(self._frame_cards))]
+        if self._prompt_test_frame_combo is not None:
+            self._prompt_test_frame_combo.configure(values=values)
+        if values and self._prompt_test_frame_var.get() not in values:
+            self._prompt_test_frame_var.set(values[0])
+        if not values:
+            self._prompt_test_frame_var.set("")
+
+        state = tk.NORMAL if values else tk.DISABLED
+        if self._prompt_test_btn is not None:
+            self._prompt_test_btn.configure(state=state)
+        if self._prompt_test_run_btn is not None:
+            self._prompt_test_run_btn.configure(state=state)
+
+    def _run_prompt_test(self):
+        if not self._frame_cards:
+            messagebox.showinfo("プロンプトテスト", "先にフレーム解析を実行してください。")
+            return
+        if self._prompt_test_tree is None:
+            self._ensure_prompt_test_window()
+        target = self._prompt_test_frame_var.get().strip()
+        try:
+            frame_index = int(target.replace("フレーム", "")) - 1
+        except ValueError:
+            frame_index = 0
+        if frame_index < 0 or frame_index >= len(self._frame_cards):
+            frame_index = 0
+
+        frame_jpeg = self._frame_cards[frame_index].get("jpeg")
+        if not frame_jpeg:
+            messagebox.showerror("プロンプトテスト", "対象フレームの画像データがありません。")
+            return
+
+        config = self._get_config()
+        base_url = config.get("ollama_base_url", "http://localhost:11434")
+        model = config.get("ollama_model", "llava")
+        prompts = _frame_prompt_tests_for_run()
+
+        if self._prompt_test_run_btn is not None:
+            self._prompt_test_run_btn.configure(state=tk.DISABLED)
+        self.status_var.set("プロンプトテストを実行中…")
+        self._progress_status_var.set("プロンプトテストを実行中…")
+        tree = self._prompt_test_tree
+        if tree is not None:
+            for item in tree.get_children():
+                tree.delete(item)
+            for prompt_def in prompts:
+                tree.insert("", tk.END, iid=prompt_def["key"], values=(prompt_def["label"], prompt_def["focus"], "待機中"))
+
+        def work():
+            results: list[tuple[dict[str, str], str]] = []
+            for prompt_def in prompts:
+                try:
+                    result = _run_frame_prompt_once(
+                        frame_jpeg,
+                        prompt_def["prompt"],
+                        base_url=base_url,
+                        model=model,
+                    )
+                except Exception as e:
+                    result = f"エラー: {e}"
+                results.append((prompt_def, result))
+
+                def _update_one(p=prompt_def, r=result):
+                    if self._prompt_test_tree is not None and self._prompt_test_tree.exists(p["key"]):
+                        self._prompt_test_tree.item(
+                            p["key"],
+                            values=(p["label"], p["focus"], _truncate_for_table(r)),
+                        )
+
+                self.after(0, _update_one)
+
+            def _done():
+                if self._prompt_test_run_btn is not None:
+                    self._prompt_test_run_btn.configure(state=tk.NORMAL)
+                self.status_var.set("プロンプトテストが完了しました")
+                self._progress_status_var.set("プロンプトテスト完了")
+                log_event(
+                    "prompt_test_done",
+                    {
+                        "frame_index": frame_index,
+                        "prompt_count": len(results),
+                    },
+                )
+
+            self.after(0, _done)
+
+        threading.Thread(target=work, daemon=True).start()
+
     def _clear_cards(self):
         self._card_images = []
         self._frame_cards = []
@@ -759,7 +1046,7 @@ class VideoAnalyzerApp(tk.Tk):
                 return "break"
             txt.bind("<MouseWheel>", _wheel_to_canvas)
             txt.bind("<Shift-MouseWheel>", _shift_wheel_to_canvas)
-            self._frame_cards.append({"label": label, "text": txt})
+            self._frame_cards.append({"label": label, "text": txt, "jpeg": jpeg_bytes})
         # カード作成前に届いていた解析結果を反映（退避した分のみ）
         for idx, result in list(pending.items()):
             if idx < len(self._frame_cards):

--- a/gui.py
+++ b/gui.py
@@ -233,8 +233,11 @@ class VideoAnalyzerApp(tk.Tk):
         self._cancel_btn: ttk.Button | None = None
         self._cancel_requested = False
         self._interval_var = tk.StringVar(value="10")
+        self._summary_window: tk.Toplevel | None = None
+        self._summary_window_btn: ttk.Button | None = None
         self._summary_btn: ttk.Button | None = None
         self._summary_text: tk.Text | None = None
+        self._summary_placeholder_var = tk.StringVar(value="総評ウィンドウで生成結果を表示します。")
         self._summary_persona_var = tk.StringVar(value=SUMMARY_PERSONA_CHOICES[0][1])
         # カード作成前に届いた解析結果を保持（レース対策）
         self._pending_frame_results: dict[int, str] = {}
@@ -401,30 +404,27 @@ class VideoAnalyzerApp(tk.Tk):
         self._progress_bar.pack(fill=tk.X, pady=(8, 0))
         self._progress_status_var.set("待機中")
 
-        # メインコンテンツ：上＝フレーム解析結果、下＝総評（縦分割で総評の表示エリアを確保）
-        SUMMARY_PANE_MIN_HEIGHT = 320  # 総評エリアの最小高さ（ピクセル）
-        content_paned = tk.PanedWindow(
-            main,
-            orient=tk.VERTICAL,
-            sashrelief=tk.FLAT,
-            sashwidth=5,
-            bg=d["bg"],
-            bd=0,
-        )
-        content_paned.pack(fill=tk.BOTH, expand=True, pady=(0, 8))
-
-        # フレームごとの解析結果（画像+テキストを同一エリアに横並び。必要ならスクロール）
+        # フレームごとの解析結果。総評は別ウィンドウ化し、この欄の表示面積を優先する。
         result_section, result_frame, _, _ = self._make_toggle_section(
-            content_paned,
+            main,
             "フレームごとの解析結果",
             fill=tk.BOTH,
             expand=True,
+            pady=(0, 8),
             padding=(16, 12),
-            pack=False,
         )
-        content_paned.add(result_section, minsize=200)
 
-        ttk.Label(result_frame, text="フレーム一覧", style="Section.TLabel").pack(anchor=tk.W, pady=(0, 4))
+        result_toolbar = ttk.Frame(result_frame)
+        result_toolbar.pack(fill=tk.X, pady=(0, 4))
+        ttk.Label(result_toolbar, text="フレーム一覧", style="Section.TLabel").pack(side=tk.LEFT)
+        self._summary_window_btn = ttk.Button(
+            result_toolbar,
+            text="総評ウィンドウ",
+            command=self._open_summary_window,
+            state=tk.DISABLED,
+            style="Accent.TButton",
+        )
+        self._summary_window_btn.pack(side=tk.RIGHT)
         ttk.Label(
             result_frame,
             text="横に並んだフレームは下の横スクロールバー、または Shift + マウスホイールで移動できます。",
@@ -479,72 +479,6 @@ class VideoAnalyzerApp(tk.Tk):
         # 後方互換のため従来の参照を維持
         self._scroll_inner = self._results_inner
         self._scroll_canvas = self._results_canvas
-
-        # 総評エリア（総評出力ボタン + 表示用テキスト・縦スクロール付き）- パネルで最低高さを確保
-        summary_section, summary_frame, _, _ = self._make_toggle_section(
-            content_paned,
-            "総評",
-            fill=tk.BOTH,
-            expand=True,
-            padding=(16, 12),
-            pack=False,
-        )
-        content_paned.add(summary_section, minsize=SUMMARY_PANE_MIN_HEIGHT)
-        summary_row = ttk.Frame(summary_frame)
-        summary_row.pack(fill=tk.X, pady=(0, 8))
-        ttk.Label(summary_row, text="人格:").pack(side=tk.LEFT, padx=(0, 6))
-        persona_combo = ttk.Combobox(
-            summary_row,
-            textvariable=self._summary_persona_var,
-            values=[lbl for _, lbl in SUMMARY_PERSONA_CHOICES],
-            state="readonly",
-            width=22,
-        )
-        persona_combo.pack(side=tk.LEFT, padx=(0, 12))
-        self._summary_btn = ttk.Button(
-            summary_row,
-            text="総評出力",
-            command=self._on_summary,
-            state=tk.DISABLED,
-            style="Accent.TButton",
-        )
-        self._summary_btn.pack(side=tk.LEFT)
-        summary_text_container = ttk.Frame(summary_frame)
-        summary_text_container.pack(fill=tk.BOTH, expand=True)
-        vscroll_summary = ttk.Scrollbar(summary_text_container)
-        vscroll_summary.pack(side=tk.RIGHT, fill=tk.Y)
-        self._summary_text = tk.Text(
-            summary_text_container,
-            wrap=tk.WORD,
-            height=14,
-            font=("Meiryo UI", 10),
-            cursor="arrow",
-            yscrollcommand=vscroll_summary.set,
-            bg=d["surface"],
-            fg=d["text_primary"],
-            insertbackground=d["accent"],
-            selectbackground=d["accent"],
-            selectforeground=d["white"],
-            relief="flat",
-            borderwidth=1,
-            highlightthickness=1,
-            highlightbackground=d["border"],
-            highlightcolor=d["accent"],
-        )
-        vscroll_summary.configure(command=self._summary_text.yview)
-        self._summary_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        _make_text_readonly(self._summary_text)
-
-        # 初期表示で総評エリアが十分見えるよう、サッシュ位置を設定（下パネルが SUMMARY_PANE_MIN_HEIGHT 以上になるように）
-        def _set_initial_sash():
-            self.update_idletasks()
-            try:
-                h = content_paned.winfo_height()
-                if h > SUMMARY_PANE_MIN_HEIGHT + 100:
-                    content_paned.sashpos(0, h - SUMMARY_PANE_MIN_HEIGHT)
-            except Exception:
-                pass
-        self.after(100, _set_initial_sash)
 
         # ステータス
         status_frame = ttk.Frame(main)
@@ -637,6 +571,75 @@ class VideoAnalyzerApp(tk.Tk):
             "ollama_japanese_model": os.environ.get("OLLAMA_JAPANESE_MODEL") or None,
             "ollama_summary_model": os.environ.get("OLLAMA_SUMMARY_MODEL") or None,
         }
+
+    def _ensure_summary_window(self) -> tk.Toplevel:
+        if self._summary_window is not None and self._summary_window.winfo_exists():
+            self._summary_window.deiconify()
+            self._summary_window.lift()
+            return self._summary_window
+
+        d = self._design
+        win = tk.Toplevel(self)
+        win.title("総評")
+        win.geometry("720x560")
+        win.minsize(520, 360)
+        win.configure(bg=d["bg"])
+        win.protocol("WM_DELETE_WINDOW", win.withdraw)
+        self._summary_window = win
+
+        main = ttk.Frame(win, padding=(16, 12))
+        main.pack(fill=tk.BOTH, expand=True)
+
+        summary_row = ttk.Frame(main)
+        summary_row.pack(fill=tk.X, pady=(0, 8))
+        ttk.Label(summary_row, text="人格:").pack(side=tk.LEFT, padx=(0, 6))
+        persona_combo = ttk.Combobox(
+            summary_row,
+            textvariable=self._summary_persona_var,
+            values=[lbl for _, lbl in SUMMARY_PERSONA_CHOICES],
+            state="readonly",
+            width=22,
+        )
+        persona_combo.pack(side=tk.LEFT, padx=(0, 12))
+        self._summary_btn = ttk.Button(
+            summary_row,
+            text="総評出力",
+            command=self._on_summary,
+            state=tk.NORMAL if self._frame_cards else tk.DISABLED,
+            style="Accent.TButton",
+        )
+        self._summary_btn.pack(side=tk.LEFT)
+
+        text_container = ttk.Frame(main)
+        text_container.pack(fill=tk.BOTH, expand=True)
+        vscroll = ttk.Scrollbar(text_container)
+        vscroll.pack(side=tk.RIGHT, fill=tk.Y)
+        self._summary_text = tk.Text(
+            text_container,
+            wrap=tk.WORD,
+            height=18,
+            font=("Meiryo UI", 10),
+            cursor="arrow",
+            yscrollcommand=vscroll.set,
+            bg=d["surface"],
+            fg=d["text_primary"],
+            insertbackground=d["accent"],
+            selectbackground=d["accent"],
+            selectforeground=d["white"],
+            relief="flat",
+            borderwidth=1,
+            highlightthickness=1,
+            highlightbackground=d["border"],
+            highlightcolor=d["accent"],
+        )
+        vscroll.configure(command=self._summary_text.yview)
+        self._summary_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        _make_text_readonly(self._summary_text)
+        self._summary_text.insert(tk.END, self._summary_placeholder_var.get())
+        return win
+
+    def _open_summary_window(self):
+        self._ensure_summary_window()
 
     def _clear_cards(self):
         self._card_images = []
@@ -964,6 +967,8 @@ class VideoAnalyzerApp(tk.Tk):
             message = f"完了（{total} フレーム解析）"
         self._hide_progress(message)
         self.analyze_btn.configure(state=tk.NORMAL)
+        if self._summary_window_btn:
+            self._summary_window_btn.configure(state=tk.NORMAL if not cancelled else tk.DISABLED)
         if self._summary_btn:
             self._summary_btn.configure(state=tk.NORMAL if not cancelled else tk.DISABLED)
         if error_count and not cancelled:

--- a/gui.py
+++ b/gui.py
@@ -339,9 +339,14 @@ class VideoAnalyzerApp(tk.Tk):
         d = self._design
         main = ttk.Frame(self, padding=(24, 16))
         main.pack(fill=tk.BOTH, expand=True)
+        main.columnconfigure(0, weight=1)
+        main.rowconfigure(3, weight=1)
 
         # 動画ファイル + 参照 + 実行
-        _, file_frame, _, _ = self._make_toggle_section(main, "動画ファイル", fill=tk.X, pady=(0, 6))
+        file_section, file_frame, _, _ = self._make_toggle_section(
+            main, "動画ファイル", fill=tk.X, pack=False
+        )
+        file_section.grid(row=0, column=0, sticky="ew", pady=(0, 6))
 
         row0 = ttk.Frame(file_frame)
         row0.pack(fill=tk.X)
@@ -374,13 +379,17 @@ class VideoAnalyzerApp(tk.Tk):
         ).pack(side=tk.LEFT, padx=(12, 0))
 
         # 動画ファイル情報
-        _, info_frame, _, _ = self._make_toggle_section(main, "動画ファイル情報", fill=tk.X, pady=(0, 12))
+        info_section, info_frame, _, _ = self._make_toggle_section(
+            main, "動画ファイル情報", fill=tk.X, pack=False
+        )
+        info_section.grid(row=1, column=0, sticky="ew", pady=(0, 12))
         ttk.Label(info_frame, textvariable=self._info_var, wraplength=600).pack(anchor=tk.W)
 
         # 解析状況: 長時間の Ollama 応答待ちをユーザーが把握できるよう常時表示する。
-        _, self._progress_frame, _, _ = self._make_toggle_section(
-            main, "解析状況", fill=tk.X, pady=(0, 12), padding=(16, 10)
+        progress_section, self._progress_frame, _, _ = self._make_toggle_section(
+            main, "解析状況", fill=tk.X, padding=(16, 10), pack=False
         )
+        progress_section.grid(row=2, column=0, sticky="ew", pady=(0, 12))
         progress_row = ttk.Frame(self._progress_frame)
         progress_row.pack(fill=tk.X)
         ttk.Label(
@@ -404,15 +413,22 @@ class VideoAnalyzerApp(tk.Tk):
         self._progress_bar.pack(fill=tk.X, pady=(8, 0))
         self._progress_status_var.set("待機中")
 
+        # 下部ステータスを先に固定し、以降のexpand領域をフレーム結果欄だけに割り当てる。
+        status_frame = ttk.Frame(main)
+        status_frame.grid(row=4, column=0, sticky="ew", pady=(8, 0))
+        ttk.Label(status_frame, textvariable=self.status_var, style="Muted.TLabel").pack(anchor=tk.W)
+        self.status_var.set("動画ファイルを選択し、実行を押してください")
+
         # フレームごとの解析結果。総評は別ウィンドウ化し、この欄の表示面積を優先する。
         result_section, result_frame, _, _ = self._make_toggle_section(
             main,
             "フレームごとの解析結果",
             fill=tk.BOTH,
             expand=True,
-            pady=(0, 8),
             padding=(16, 12),
+            pack=False,
         )
+        result_section.grid(row=3, column=0, sticky="nsew", pady=(0, 8))
 
         result_toolbar = ttk.Frame(result_frame)
         result_toolbar.pack(fill=tk.X, pady=(0, 4))
@@ -479,12 +495,6 @@ class VideoAnalyzerApp(tk.Tk):
         # 後方互換のため従来の参照を維持
         self._scroll_inner = self._results_inner
         self._scroll_canvas = self._results_canvas
-
-        # ステータス
-        status_frame = ttk.Frame(main)
-        status_frame.pack(fill=tk.X, pady=(8, 0))
-        ttk.Label(status_frame, textvariable=self.status_var, style="Muted.TLabel").pack(anchor=tk.W)
-        self.status_var.set("動画ファイルを選択し、実行を押してください")
 
     def _show_progress(self, msg: str, current: int, total: int):
         """状況エリアのメッセージとプログレスバーを更新"""

--- a/gui.py
+++ b/gui.py
@@ -290,7 +290,7 @@ class VideoAnalyzerApp(tk.Tk):
         padding=(16, 12),
         initially_visible: bool = True,
         pack: bool = True,
-    ) -> tuple[ttk.Frame, ttk.Frame, ttk.Button, Callable[[], None]]:
+    ) -> tuple[ttk.Frame, ttk.Frame, ttk.Label, Callable[[], None]]:
         section = ttk.Frame(parent)
         if pack:
             section.pack(fill=fill, expand=expand, pady=pady)
@@ -306,20 +306,25 @@ class VideoAnalyzerApp(tk.Tk):
             if visible.get():
                 if not body.winfo_ismapped():
                     body.pack(fill=fill, expand=expand)
-                toggle_btn.configure(text="非表示")
+                toggle_label.configure(text="▲")
             else:
                 body.pack_forget()
-                toggle_btn.configure(text="表示")
+                toggle_label.configure(text="▼")
             self.after_idle(self._refresh_layout_after_toggle)
 
-        def _toggle() -> None:
+        def _toggle(_event=None) -> str:
             visible.set(not visible.get())
             _set_body_visibility()
+            return "break"
 
-        toggle_btn = ttk.Button(header, text="非表示", command=_toggle, width=8)
-        toggle_btn.pack(side=tk.LEFT, padx=(8, 0))
+        toggle_label = ttk.Label(header, text="▲", style="Section.TLabel", cursor="hand2")
+        toggle_label.pack(side=tk.LEFT, padx=(8, 0))
+        toggle_label.bind("<Button-1>", _toggle)
+        toggle_label.bind("<Return>", _toggle)
+        toggle_label.bind("<space>", _toggle)
+        toggle_label.configure(takefocus=1)
         _set_body_visibility()
-        return section, body, toggle_btn, _toggle
+        return section, body, toggle_label, _toggle
 
     def _refresh_layout_after_toggle(self) -> None:
         self.update_idletasks()

--- a/gui.py
+++ b/gui.py
@@ -225,6 +225,7 @@ class VideoAnalyzerApp(tk.Tk):
         self._images_canvas: tk.Canvas | None = None
         self._results_inner: ttk.Frame | None = None
         self._results_canvas: tk.Canvas | None = None
+        self._results_hscroll: ttk.Scrollbar | None = None
         self._info_var = tk.StringVar(value="動画を選択してください")
         self._progress_status_var = tk.StringVar(value="")
         self._progress_bar: ttk.Progressbar | None = None
@@ -424,8 +425,15 @@ class VideoAnalyzerApp(tk.Tk):
         content_paned.add(result_section, minsize=200)
 
         ttk.Label(result_frame, text="フレーム一覧", style="Section.TLabel").pack(anchor=tk.W, pady=(0, 4))
+        ttk.Label(
+            result_frame,
+            text="横に並んだフレームは下の横スクロールバー、または Shift + マウスホイールで移動できます。",
+            style="Muted.TLabel",
+        ).pack(anchor=tk.W, pady=(0, 6))
         cards_container = ttk.Frame(result_frame)
         cards_container.pack(fill=tk.BOTH, expand=True)
+        cards_container.columnconfigure(0, weight=1)
+        cards_container.rowconfigure(0, weight=1)
 
         self._results_canvas = tk.Canvas(
             cards_container,
@@ -435,12 +443,19 @@ class VideoAnalyzerApp(tk.Tk):
             highlightcolor=d["border"],
         )
         cards_vscroll = ttk.Scrollbar(cards_container, orient="vertical", command=self._results_canvas.yview)
-        # 全体（カード一覧）の横スクロール。キャンバスと同じコンテナに置くことで常に見えるようにする。
-        cards_hscroll = ttk.Scrollbar(cards_container, orient="horizontal", command=self._results_canvas.xview)
-        self._results_canvas.configure(xscrollcommand=cards_hscroll.set, yscrollcommand=cards_vscroll.set)
-        cards_vscroll.pack(side=tk.RIGHT, fill=tk.Y)
-        self._results_canvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        cards_hscroll.pack(side=tk.BOTTOM, fill=tk.X, pady=(6, 0))
+        # grid で横スクロールバーを独立行に固定し、横並びカードでも常に操作できるようにする。
+        self._results_hscroll = ttk.Scrollbar(
+            cards_container,
+            orient="horizontal",
+            command=self._results_canvas.xview,
+        )
+        self._results_canvas.configure(
+            xscrollcommand=self._results_hscroll.set,
+            yscrollcommand=cards_vscroll.set,
+        )
+        self._results_canvas.grid(row=0, column=0, sticky="nsew")
+        cards_vscroll.grid(row=0, column=1, sticky="ns")
+        self._results_hscroll.grid(row=1, column=0, sticky="ew", pady=(6, 0))
 
         self._results_inner = ttk.Frame(self._results_canvas)
         self._results_win_id = self._results_canvas.create_window((0, 0), window=self._results_inner, anchor="nw")

--- a/gui.py
+++ b/gui.py
@@ -279,14 +279,60 @@ class VideoAnalyzerApp(tk.Tk):
         style.configure("Muted.TLabel", background=bg, foreground=fg_muted, font=("Meiryo UI", 9))
         style.configure("Section.TLabel", background=bg, foreground=fg, font=("Meiryo UI", 10, "bold"))
 
+    def _make_toggle_section(
+        self,
+        parent,
+        title: str,
+        *,
+        fill=tk.X,
+        expand=False,
+        pady=(0, 12),
+        padding=(16, 12),
+        initially_visible: bool = True,
+        pack: bool = True,
+    ) -> tuple[ttk.Frame, ttk.Frame, ttk.Button, Callable[[], None]]:
+        section = ttk.Frame(parent)
+        if pack:
+            section.pack(fill=fill, expand=expand, pady=pady)
+
+        header = ttk.Frame(section)
+        header.pack(fill=tk.X, pady=(0, 4))
+        ttk.Label(header, text=title, style="Section.TLabel").pack(side=tk.LEFT)
+
+        body = ttk.LabelFrame(section, padding=padding)
+        visible = tk.BooleanVar(value=initially_visible)
+
+        def _set_body_visibility() -> None:
+            if visible.get():
+                if not body.winfo_ismapped():
+                    body.pack(fill=fill, expand=expand)
+                toggle_btn.configure(text="非表示")
+            else:
+                body.pack_forget()
+                toggle_btn.configure(text="表示")
+            self.after_idle(self._refresh_layout_after_toggle)
+
+        def _toggle() -> None:
+            visible.set(not visible.get())
+            _set_body_visibility()
+
+        toggle_btn = ttk.Button(header, text="非表示", command=_toggle, width=8)
+        toggle_btn.pack(side=tk.LEFT, padx=(8, 0))
+        _set_body_visibility()
+        return section, body, toggle_btn, _toggle
+
+    def _refresh_layout_after_toggle(self) -> None:
+        self.update_idletasks()
+        if self._results_canvas:
+            self._results_canvas.configure(scrollregion=self._results_canvas.bbox("all"))
+
     def _build_ui(self):
         d = self._design
         main = ttk.Frame(self, padding=(24, 16))
         main.pack(fill=tk.BOTH, expand=True)
 
         # 動画ファイル + 参照 + 実行
-        file_frame = ttk.LabelFrame(main, text="動画ファイル", padding=(16, 12))
-        file_frame.pack(fill=tk.X, pady=(0, 6))
+        _, file_frame, _, _ = self._make_toggle_section(main, "動画ファイル", fill=tk.X, pady=(0, 6))
 
         row0 = ttk.Frame(file_frame)
         row0.pack(fill=tk.X)
@@ -319,13 +365,13 @@ class VideoAnalyzerApp(tk.Tk):
         ).pack(side=tk.LEFT, padx=(12, 0))
 
         # 動画ファイル情報
-        info_frame = ttk.LabelFrame(main, text="動画ファイル情報", padding=(16, 12))
-        info_frame.pack(fill=tk.X, pady=(0, 12))
+        _, info_frame, _, _ = self._make_toggle_section(main, "動画ファイル情報", fill=tk.X, pady=(0, 12))
         ttk.Label(info_frame, textvariable=self._info_var, wraplength=600).pack(anchor=tk.W)
 
         # 解析状況: 長時間の Ollama 応答待ちをユーザーが把握できるよう常時表示する。
-        self._progress_frame = ttk.LabelFrame(main, text="解析状況", padding=(16, 10))
-        self._progress_frame.pack(fill=tk.X, pady=(0, 12))
+        _, self._progress_frame, _, _ = self._make_toggle_section(
+            main, "解析状況", fill=tk.X, pady=(0, 12), padding=(16, 10)
+        )
         progress_row = ttk.Frame(self._progress_frame)
         progress_row.pack(fill=tk.X)
         ttk.Label(
@@ -362,8 +408,15 @@ class VideoAnalyzerApp(tk.Tk):
         content_paned.pack(fill=tk.BOTH, expand=True, pady=(0, 8))
 
         # フレームごとの解析結果（画像+テキストを同一エリアに横並び。必要ならスクロール）
-        result_frame = ttk.LabelFrame(content_paned, text="フレームごとの解析結果", padding=(16, 12))
-        content_paned.add(result_frame, minsize=200)
+        result_section, result_frame, _, _ = self._make_toggle_section(
+            content_paned,
+            "フレームごとの解析結果",
+            fill=tk.BOTH,
+            expand=True,
+            padding=(16, 12),
+            pack=False,
+        )
+        content_paned.add(result_section, minsize=200)
 
         ttk.Label(result_frame, text="フレーム一覧", style="Section.TLabel").pack(anchor=tk.W, pady=(0, 4))
         cards_container = ttk.Frame(result_frame)
@@ -408,8 +461,15 @@ class VideoAnalyzerApp(tk.Tk):
         self._scroll_canvas = self._results_canvas
 
         # 総評エリア（総評出力ボタン + 表示用テキスト・縦スクロール付き）- パネルで最低高さを確保
-        summary_frame = ttk.LabelFrame(content_paned, text="総評", padding=(16, 12))
-        content_paned.add(summary_frame, minsize=SUMMARY_PANE_MIN_HEIGHT)
+        summary_section, summary_frame, _, _ = self._make_toggle_section(
+            content_paned,
+            "総評",
+            fill=tk.BOTH,
+            expand=True,
+            padding=(16, 12),
+            pack=False,
+        )
+        content_paned.add(summary_section, minsize=SUMMARY_PANE_MIN_HEIGHT)
         summary_row = ttk.Frame(summary_frame)
         summary_row.pack(fill=tk.X, pady=(0, 8))
         ttk.Label(summary_row, text="人格:").pack(side=tk.LEFT, padx=(0, 6))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep the frame results horizontal scrollbar visible and usable for horizontally arranged cards.
- Add guidance text explaining that users can use the lower scrollbar or Shift + mouse wheel to move across frame cards.
- Move the summary UI out of the main window into a separate summary window so the frame results area has more vertical space.
- Make the frame results section absorb vertical space when other sections are collapsed.
- Add a prompt test mode window that compares the existing frame prompt plus three new prompt variants in a table.

## Walkthrough
[gui_prompt_test_window_demo.mp4](https://cursor.com/agents/bc-6656725a-8be3-481e-8560-f1fd7f14d726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgui_prompt_test_window_demo.mp4)

[gui_result_area_fill_grid_demo.mp4](https://cursor.com/agents/bc-6656725a-8be3-481e-8560-f1fd7f14d726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgui_result_area_fill_grid_demo.mp4)

[gui_summary_separate_window_demo.mp4](https://cursor.com/agents/bc-6656725a-8be3-481e-8560-f1fd7f14d726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgui_summary_separate_window_demo.mp4)

[gui_horizontal_scroll_demo.mp4](https://cursor.com/agents/bc-6656725a-8be3-481e-8560-f1fd7f14d726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgui_horizontal_scroll_demo.mp4)

[Prompt test mode results](https://cursor.com/agents/bc-6656725a-8be3-481e-8560-f1fd7f14d726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgui_prompt_test_window_results.webp)
[Frame results fill collapsed section space](https://cursor.com/agents/bc-6656725a-8be3-481e-8560-f1fd7f14d726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgui_result_area_fill_grid.webp)
[Summary separate window](https://cursor.com/agents/bc-6656725a-8be3-481e-8560-f1fd7f14d726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgui_summary_separate_window.webp)
[Horizontal scroll for frame cards](https://cursor.com/agents/bc-6656725a-8be3-481e-8560-f1fd7f14d726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgui_horizontal_scroll_cards.webp)

## Testing
- `python -m py_compile gui.py`
- GUI smoke test confirming prompt test definitions include 4 prompts: existing detailed report, short summary, tag extraction, and judgement-focused prompt.
- GUI smoke test with mocked prompt execution confirming the prompt test table renders 4 rows and updates results.
- Manual GUI test confirming the prompt test button opens a dedicated window with target frame selection, compare button, and a table of existing + three new prompt results.
- GUI geometry smoke test confirming the frame results canvas grows from 73px to 372px after collapsing the three upper sections.
- Manual GUI test confirming the frame results horizontal scrollbar is visible, scrolls right to hidden cards, and scrolls back left.

Refs #2

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6656725a-8be3-481e-8560-f1fd7f14d726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6656725a-8be3-481e-8560-f1fd7f14d726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

